### PR TITLE
Tune MPC controller to increase min turning radius

### DIFF
--- a/master3_nav2/config/nav2_params-MPPIController.yaml
+++ b/master3_nav2/config/nav2_params-MPPIController.yaml
@@ -199,7 +199,7 @@ controller_server:
         time_step: 3
       AckermannConstraints:
         # minimum turning radius for ackermann motion model
-        min_turning_r: 0.2
+        min_turning_r: 0.5
       # Default: None. Critics (plugins) names
       critics: [
         "ConstraintCritic", "CostCritic", "GoalCritic",

--- a/master3_nav2/config/nav2_params.yaml
+++ b/master3_nav2/config/nav2_params.yaml
@@ -241,6 +241,8 @@ controller_server:
       RotateToGoal.scale: 1.0
       RotateToGoal.slowing_factor: 1.3
       RotateToGoal.lookahead_time: -1.0
+      AckermannConstraints:
+        min_turning_r: 0.5
     
 
 local_costmap:
@@ -575,7 +577,7 @@ global_costmap:
           vertical_fov_angle: 0.8745
           horizontal_fov_angle: 1.048
           decay_acceleration: 15.0
-          model_type: 0
+          model_type: 0        
       always_send_full_costmap: False
 
 map_server:


### PR DESCRIPTION
Fixes #1

Increase the minimum turning radius for Ackermann constraints in the MPC controller configuration.

* **master3_nav2/config/nav2_params-MPPIController.yaml**
  - Increase the `min_turning_r` parameter from 0.2 to 0.5.

* **master3_nav2/config/nav2_params.yaml**
  - Add the `AckermannConstraints` section with the `min_turning_r` parameter set to 0.5.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cord-burmeister/master3_nav/issues/1?shareId=6e36561d-9a62-4a8b-a21f-9fc64e07bb28).